### PR TITLE
Remove trailing spaces in file names.

### DIFF
--- a/pygmynote.py
+++ b/pygmynote.py
@@ -157,7 +157,7 @@ q	Quit"""
 			notetags = escapechar(raw_input('Tags: '))
 			notefile = escapechar(raw_input('Enter path to file: '))
 			notetype="A"
-			f=open(notefile, 'rb')
+			f=open(notefile.rstrip(), 'rb')
 			ablob = f.read()
 			f.close()
 			cursor.execute("INSERT INTO notes (note, tags, type, ext, file) VALUES('" + notetext + "', '" + notetags + "', '" + notetype + "', '"  + notefile[-3:] + "', ?)", [sqlite.Binary(ablob)])

--- a/pygmynote3.py
+++ b/pygmynote3.py
@@ -149,7 +149,7 @@ q	Quit""")
 			notetags = escapechar(input('Tags: '))
 			notefile = escapechar(input('Enter path to file: '))
 			notetype='A'
-			f=open(notefile, 'rb')
+			f=open(notefile.rstrip(), 'rb')
 			ablob = f.read()
 			f.close()
 			cursor.execute("INSERT INTO notes (note, tags, type, ext, file) VALUES('" + notetext + "', '" + notetags + "', '" + notetype + "', '"  + notefile[-3:] + "', ?)", [sqlite.Binary(ablob)])


### PR DESCRIPTION
I added and rstrip call to the notefile variable when adding a file attachment. I was getting an error when dragging a file from the Finder because a space is added by default at the end of the file name.
